### PR TITLE
feat: add db models

### DIFF
--- a/backend/src/api.module.ts
+++ b/backend/src/api.module.ts
@@ -17,6 +17,7 @@ import { OptionModule } from 'option/option.module'
 // import { OtpModule } from 'otp/otp.module'
 // import { MailerModule } from 'mailer/mailer.module'
 
+// TODO: to remove modules here that are used by other modules
 const apiModules = [
   TerminusModule,
   HealthModule,

--- a/backend/src/api.module.ts
+++ b/backend/src/api.module.ts
@@ -5,12 +5,29 @@ import { TerminusModule } from '@nestjs/terminus'
 import { HealthModule } from './health/health.module'
 import { ConfigService } from 'config/config.service'
 import { RouterModule } from '@nestjs/core'
+import { CreatorModule } from 'creator/creator.module'
+import { UserModule } from 'user/user.module'
+import { UserQuizCategoryModule } from 'userQuizCategory/userQuizCategory.module'
+import { SubmissionModule } from 'submission/submission.module'
+import { QuizQuestionModule } from 'quizQuestion/quizQuestion.module'
+import { QuestionModule } from 'question/question.module'
+import { OptionModule } from 'option/option.module'
 // TODO: to uncomment and implement should we decide to add these in
 // import { AuthModule } from 'auth/auth.module'
 // import { OtpModule } from 'otp/otp.module'
 // import { MailerModule } from 'mailer/mailer.module'
 
-const apiModules = [TerminusModule, HealthModule]
+const apiModules = [
+  TerminusModule,
+  HealthModule,
+  CreatorModule,
+  UserModule,
+  UserQuizCategoryModule,
+  SubmissionModule,
+  QuizQuestionModule,
+  QuestionModule,
+  OptionModule,
+]
 
 @Module({
   imports: [

--- a/backend/src/database/models/index.ts
+++ b/backend/src/database/models/index.ts
@@ -1,1 +1,7 @@
 export * from './user'
+export * from './userQuizCategory'
+export * from './quiz'
+export * from './submission'
+export * from './quizQuestion'
+export * from './question'
+export * from './option'

--- a/backend/src/database/models/option.ts
+++ b/backend/src/database/models/option.ts
@@ -1,0 +1,49 @@
+import {
+  BelongsTo,
+  Column,
+  CreatedAt,
+  DataType,
+  ForeignKey,
+  Model,
+  Table,
+  UpdatedAt,
+} from 'sequelize-typescript'
+import { Question } from '.'
+
+@Table({ tableName: 'options' })
+export class Option extends Model {
+  @Column({
+    primaryKey: true,
+    type: DataType.INTEGER,
+    autoIncrement: true,
+  })
+  id!: number
+
+  @ForeignKey(() => Question)
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
+  questionId!: number
+
+  @Column({
+    type: DataType.TEXT,
+    allowNull: false,
+  })
+  text!: string
+
+  @Column({
+    type: DataType.BOOLEAN,
+    allowNull: false,
+  })
+  isTrue!: boolean
+
+  @BelongsTo(() => Question)
+  question!: Question
+
+  @CreatedAt
+  createdAt!: Date
+
+  @UpdatedAt
+  updatedAt!: Date
+}

--- a/backend/src/database/models/question.ts
+++ b/backend/src/database/models/question.ts
@@ -1,0 +1,72 @@
+import {
+  Column,
+  CreatedAt,
+  DataType,
+  HasMany,
+  Model,
+  Table,
+  UpdatedAt,
+} from 'sequelize-typescript'
+import { QuizQuestion, Option } from '.'
+
+const QUESTION_TYPES = ['MCQ-1', 'MCM-M', 'T/F'] as const
+export type QuestionType = typeof QUESTION_TYPES[number]
+
+@Table({ tableName: 'questions' })
+export class Question extends Model {
+  @Column({
+    primaryKey: true,
+    type: DataType.INTEGER,
+    autoIncrement: true,
+  })
+  id!: number
+
+  @Column({
+    type: DataType.TEXT,
+    allowNull: false,
+  })
+  text!: string
+
+  @Column({
+    type: DataType.TEXT,
+    allowNull: false,
+  })
+  details!: string
+
+  @Column({
+    type: DataType.TEXT,
+    allowNull: false,
+  })
+  explanation!: string
+
+  @Column({
+    type: DataType.STRING(200),
+    allowNull: false,
+  })
+  mediaURL!: string
+
+  // TODO: test ENUM
+  @Column({
+    type: DataType.ENUM(...QUESTION_TYPES),
+    allowNull: false,
+  })
+  type!: QuestionType
+
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
+  pointValue!: string
+
+  @HasMany(() => QuizQuestion)
+  quizQuestions!: QuizQuestion[]
+
+  @HasMany(() => Option)
+  options!: Option[]
+
+  @CreatedAt
+  createdAt!: Date
+
+  @UpdatedAt
+  updatedAt!: Date
+}

--- a/backend/src/database/models/quiz.ts
+++ b/backend/src/database/models/quiz.ts
@@ -1,0 +1,79 @@
+import {
+  BelongsTo,
+  Column,
+  CreatedAt,
+  DataType,
+  ForeignKey,
+  HasMany,
+  Model,
+  Table,
+  UpdatedAt,
+} from 'sequelize-typescript'
+import { QuizQuestion, Submission, User, UserQuizCategory } from '.'
+
+@Table({ tableName: 'quizzes' })
+export class Quiz extends Model {
+  @Column({
+    primaryKey: true,
+    type: DataType.INTEGER,
+    autoIncrement: true,
+  })
+  id!: number
+
+  @Column({
+    type: DataType.STRING,
+    unique: true,
+    allowNull: false,
+  })
+  name!: string
+
+  @ForeignKey(() => User)
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
+  ownerId!: number
+
+  @ForeignKey(() => UserQuizCategory)
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
+  categoryId!: number
+
+  @Column({
+    type: DataType.FLOAT,
+    allowNull: false,
+  })
+  passingPercent!: number
+
+  @Column({
+    type: DataType.TEXT,
+    allowNull: false,
+  })
+  description!: string
+
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  organisation!: string
+
+  @BelongsTo(() => User)
+  user!: User
+
+  @BelongsTo(() => UserQuizCategory)
+  userQuizCategory!: UserQuizCategory
+
+  @HasMany(() => Submission)
+  submissions!: Submission[]
+
+  @HasMany(() => QuizQuestion)
+  quizQuestions!: QuizQuestion[]
+
+  @CreatedAt
+  createdAt!: Date
+
+  @UpdatedAt
+  updatedAt!: Date
+}

--- a/backend/src/database/models/quizQuestion.ts
+++ b/backend/src/database/models/quizQuestion.ts
@@ -1,0 +1,60 @@
+import {
+  BelongsTo,
+  Column,
+  CreatedAt,
+  DataType,
+  ForeignKey,
+  Model,
+  Table,
+  UpdatedAt,
+} from 'sequelize-typescript'
+import { Question, Quiz } from '.'
+
+@Table({ tableName: 'quiz-questions' })
+export class QuizQuestion extends Model {
+  @Column({
+    primaryKey: true,
+    type: DataType.INTEGER,
+    autoIncrement: true,
+  })
+  id!: number
+
+  @ForeignKey(() => Quiz)
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
+  quizId!: number
+
+  @ForeignKey(() => Question)
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
+  questionId!: number
+
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
+  position!: number
+
+  // TODO: check duplicate attribute with Question
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
+  pointValue!: number
+
+  @BelongsTo(() => Quiz)
+  quiz!: Quiz
+
+  @BelongsTo(() => Question)
+  question!: Question
+
+  @CreatedAt
+  createdAt!: Date
+
+  @UpdatedAt
+  updatedAt!: Date
+}

--- a/backend/src/database/models/quizQuestion.ts
+++ b/backend/src/database/models/quizQuestion.ts
@@ -23,6 +23,7 @@ export class QuizQuestion extends Model {
   @Column({
     type: DataType.INTEGER,
     allowNull: false,
+    unique: 'quiz-question-unique',
   })
   quizId!: number
 
@@ -30,6 +31,7 @@ export class QuizQuestion extends Model {
   @Column({
     type: DataType.INTEGER,
     allowNull: false,
+    unique: 'quiz-question-unique',
   })
   questionId!: number
 

--- a/backend/src/database/models/submission.ts
+++ b/backend/src/database/models/submission.ts
@@ -1,0 +1,68 @@
+import {
+  BelongsTo,
+  Column,
+  CreatedAt,
+  DataType,
+  ForeignKey,
+  Model,
+  Table,
+  UpdatedAt,
+} from 'sequelize-typescript'
+import { Quiz } from '.'
+
+export type SubmissionType = {
+  questions: {
+    id: number
+    answer: unknown
+  }[]
+}
+
+@Table({ tableName: 'submissions' })
+export class Submission extends Model {
+  @Column({
+    primaryKey: true,
+    type: DataType.INTEGER,
+    autoIncrement: true,
+  })
+  id!: number
+
+  @ForeignKey(() => Quiz)
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
+  quizId!: number
+
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  name!: string
+
+  @Column({
+    type: DataType.FLOAT,
+    allowNull: false,
+  })
+  scorePercent!: number
+
+  @Column({
+    type: DataType.JSON,
+    allowNull: false,
+  })
+  submission!: SubmissionType
+
+  @Column({
+    type: DataType.STRING(15),
+    allowNull: false,
+  })
+  sourceIP!: string
+
+  @BelongsTo(() => Quiz)
+  quiz!: Quiz
+
+  @CreatedAt
+  submittedAt!: Date
+
+  @UpdatedAt
+  updatedAt!: Date
+}

--- a/backend/src/database/models/user.ts
+++ b/backend/src/database/models/user.ts
@@ -20,7 +20,6 @@ export class User extends Model {
 
   @Column({
     type: DataType.STRING,
-    unique: true,
     allowNull: false,
   })
   name!: string

--- a/backend/src/database/models/userQuizCategory.ts
+++ b/backend/src/database/models/userQuizCategory.ts
@@ -22,7 +22,7 @@ export class UserQuizCategory extends Model {
 
   @ForeignKey(() => User)
   @Column({
-    type: DataType.STRING,
+    type: DataType.INTEGER,
     allowNull: false,
   })
   userId!: number

--- a/backend/src/database/models/userQuizCategory.ts
+++ b/backend/src/database/models/userQuizCategory.ts
@@ -1,22 +1,31 @@
 import {
+  BelongsTo,
   Column,
   CreatedAt,
   DataType,
+  ForeignKey,
   HasMany,
   Model,
   Table,
   UpdatedAt,
 } from 'sequelize-typescript'
-import { Quiz, UserQuizCategory } from '.'
+import { Quiz, User } from '.'
 
-@Table({ tableName: 'users' })
-export class User extends Model {
+@Table({ tableName: 'user-quiz-categories' })
+export class UserQuizCategory extends Model {
   @Column({
     primaryKey: true,
     type: DataType.INTEGER,
     autoIncrement: true,
   })
   id!: number
+
+  @ForeignKey(() => User)
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  userId!: number
 
   @Column({
     type: DataType.STRING,
@@ -25,15 +34,8 @@ export class User extends Model {
   })
   name!: string
 
-  @Column({
-    type: DataType.STRING,
-    unique: true,
-    allowNull: false,
-  })
-  email!: string
-
-  @HasMany(() => UserQuizCategory)
-  userQuizCategories!: UserQuizCategory[]
+  @BelongsTo(() => User)
+  user!: User
 
   @HasMany(() => Quiz)
   quizzes!: Quiz[]

--- a/backend/src/option/option.module.ts
+++ b/backend/src/option/option.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+import { Option } from 'database/models'
+import { OptionService } from './option.service'
+
+@Module({
+  imports: [SequelizeModule.forFeature([Option])],
+  providers: [OptionService],
+  exports: [OptionService],
+})
+export class OptionModule {}

--- a/backend/src/option/option.service.ts
+++ b/backend/src/option/option.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+import { Option } from '../database/models'
+
+@Injectable()
+export class OptionService {
+  constructor(
+    @InjectModel(Option)
+    private readonly optionModel: typeof Option
+  ) {}
+}

--- a/backend/src/question/question.module.ts
+++ b/backend/src/question/question.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+import { Question } from 'database/models'
+import { QuestionService } from './question.service'
+
+@Module({
+  imports: [SequelizeModule.forFeature([Question])],
+  providers: [QuestionService],
+  exports: [QuestionService],
+})
+export class QuestionModule {}

--- a/backend/src/question/question.service.ts
+++ b/backend/src/question/question.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+import { Question } from '../database/models'
+
+@Injectable()
+export class QuestionService {
+  constructor(
+    @InjectModel(Question)
+    private readonly questionModel: typeof Question
+  ) {}
+}

--- a/backend/src/quiz/quiz.module.ts
+++ b/backend/src/quiz/quiz.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+import { Quiz } from 'database/models'
+import { QuizService } from './quiz.service'
+
+@Module({
+  imports: [SequelizeModule.forFeature([Quiz])],
+  providers: [QuizService],
+  exports: [QuizService],
+})
+export class QuizModule {}

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+import { Quiz } from '../database/models'
+
+@Injectable()
+export class QuizService {
+  constructor(
+    @InjectModel(Quiz)
+    private readonly quizModel: typeof Quiz
+  ) {}
+
+  // TODO: incomplete. missing quiz questions
+  async createQuiz(
+    userId: number,
+    name: string,
+    categoryId: number,
+    passingPercent: number,
+    description: string,
+    organisation: string
+  ): Promise<Quiz> {
+    return this.quizModel.create({
+      name,
+      ownerId: userId,
+      categoryId,
+      passingPercent,
+      description,
+      organisation,
+    })
+  }
+
+  async getAllFromCreator(userId: number): Promise<Quiz[]> {
+    return this.quizModel.findAll({ where: { ownerId: userId } })
+  }
+}

--- a/backend/src/quizQuestion/quizQuestion.module.ts
+++ b/backend/src/quizQuestion/quizQuestion.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+import { QuizQuestion } from 'database/models'
+import { QuizQuestionService } from './quizQuestion.service'
+
+@Module({
+  imports: [SequelizeModule.forFeature([QuizQuestion])],
+  providers: [QuizQuestionService],
+  exports: [QuizQuestionService],
+})
+export class QuizQuestionModule {}

--- a/backend/src/quizQuestion/quizQuestion.service.ts
+++ b/backend/src/quizQuestion/quizQuestion.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+import { QuizQuestion } from '../database/models'
+
+@Injectable()
+export class QuizQuestionService {
+  constructor(
+    @InjectModel(QuizQuestion)
+    private readonly quizQuestionModel: typeof QuizQuestion
+  ) {}
+}

--- a/backend/src/submission/submission.module.ts
+++ b/backend/src/submission/submission.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+import { Submission } from 'database/models'
+import { SubmissionService } from './submission.service'
+
+@Module({
+  imports: [SequelizeModule.forFeature([Submission])],
+  providers: [SubmissionService],
+  exports: [SubmissionService],
+})
+export class SubmissionModule {}

--- a/backend/src/submission/submission.service.ts
+++ b/backend/src/submission/submission.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+import { Submission } from '../database/models'
+
+@Injectable()
+export class SubmissionService {
+  constructor(
+    @InjectModel(Submission)
+    private readonly submissionModel: typeof Submission
+  ) {}
+}

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+import { User } from 'database/models'
+import { UserService } from './user.service'
+
+@Module({
+  imports: [SequelizeModule.forFeature([User])],
+  providers: [UserService],
+  exports: [UserService],
+})
+export class UserModule {}

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+import { User } from '../database/models'
+
+@Injectable()
+export class UserService {
+  constructor(
+    @InjectModel(User)
+    private readonly userModel: typeof User
+  ) {}
+}

--- a/backend/src/userQuizCategory/userQuizCategory.module.ts
+++ b/backend/src/userQuizCategory/userQuizCategory.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+import { UserQuizCategory } from 'database/models'
+import { UserQuizCategoryService } from './userQuizCategory.service'
+
+@Module({
+  imports: [SequelizeModule.forFeature([UserQuizCategory])],
+  providers: [UserQuizCategoryService],
+  exports: [UserQuizCategoryService],
+})
+export class UserQuizCategoryModule {}

--- a/backend/src/userQuizCategory/userQuizCategory.service.ts
+++ b/backend/src/userQuizCategory/userQuizCategory.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+import { UserQuizCategory } from '../database/models'
+
+@Injectable()
+export class UserQuizCategoryService {
+  constructor(
+    @InjectModel(UserQuizCategory)
+    private readonly userQuizCategoryModel: typeof UserQuizCategory
+  ) {}
+}


### PR DESCRIPTION
## Context

DB Schemas can found in this [Lucidchart](https://lucid.app/lucidchart/9b1fbd10-e390-4ca7-9f54-d791baf7dcef/edit?invitationId=inv_a444d1c2-820d-4d0d-84ab-d62a1a050907&referringApp=slack&page=0_0#)

Schemas added:
- `UserQuizCategory`
- `Quiz`
- `Submission`
- `QuizQuestion`
- `Question`
- `Option`

Schemas edited:
- `User`

## Tests

- [x]  Check for foreign key constraints
  - `QuizQuestion`: `quizId`, `questionId` 