### PR TITLE
feat: handle quiz submissions

### DIFF
--- a/backend/src/taker/dto/submit-quiz.dto.ts
+++ b/backend/src/taker/dto/submit-quiz.dto.ts
@@ -1,0 +1,17 @@
+import { IsNumber, IsNotEmpty, MinLength } from 'class-validator'
+
+export class QuestionAnswerDto {
+  @IsNumber()
+  id!: number
+
+  @IsNotEmpty()
+  answer!: number[]
+}
+
+export class SubmissionDto {
+  @MinLength(1)
+  name!: string
+
+  @IsNotEmpty()
+  questions!: QuestionAnswerDto[]
+}

--- a/backend/src/taker/taker.controller.ts
+++ b/backend/src/taker/taker.controller.ts
@@ -3,24 +3,24 @@ import {
   HttpStatus,
   Res,
   Get,
+  Post,
+  Body,
   Param,
-  NotFoundException,
+  BadRequestException,
   InternalServerErrorException,
+  NotFoundException,
 } from '@nestjs/common'
 import { Response } from 'express'
-import { OptionService } from 'option/option.service'
-import { QuestionService } from 'question/question.service'
 import { QuizService } from 'quiz/quiz.service'
-import { UserService } from 'user/user.service'
 import { IsNumberStringValidator } from 'helpers/isNumberStringValidator'
+import { SubmissionDto } from './dto/submit-quiz.dto'
+import { TakerService } from './taker.service'
 
 @Controller('')
 export class TakerController {
   constructor(
-    private readonly userService: UserService,
     private readonly quizService: QuizService,
-    private readonly questionService: QuestionService,
-    private readonly optionService: OptionService
+    private readonly takerService: TakerService
   ) {}
 
   @Get('quiz/:id/attempt')
@@ -28,13 +28,38 @@ export class TakerController {
     @Res() res: Response,
     @Param() param: IsNumberStringValidator
   ): Promise<void> {
-    const admin = await this.userService.getFirst()
-    if (!admin) throw new InternalServerErrorException('Admin user not present')
     const quiz = await this.quizService.getQuiz(param.id)
+
+    // TODO: subset, randomization on questions and options
+    // TODO: store quiz to user session (to prevent foul play on submission!)
 
     if (!quiz) throw new NotFoundException()
     res
       .status(HttpStatus.OK)
       .json(this.quizService.formQuizAttemptResponse(quiz))
+  }
+
+  @Post('quiz/:id/submission')
+  async postSubmission(
+    @Res() res: Response,
+    @Body() submission: SubmissionDto,
+    @Param() param: IsNumberStringValidator
+  ): Promise<void> {
+    const quiz = await this.quizService.getQuiz(param.id)
+
+    if (!quiz) throw new NotFoundException()
+
+    try {
+      this.takerService.assertValidSubmission(quiz, submission)
+    } catch (err) {
+      throw new BadRequestException('Response does not match quiz definition')
+    }
+
+    try {
+      const submissionResponse = this.takerService.mark(quiz, submission)
+      res.status(HttpStatus.OK).json(submissionResponse)
+    } catch (err) {
+      throw new InternalServerErrorException('Unable to mark quiz submission')
+    }
   }
 }

--- a/backend/src/taker/taker.controller.ts
+++ b/backend/src/taker/taker.controller.ts
@@ -51,8 +51,10 @@ export class TakerController {
 
     try {
       this.takerService.assertValidSubmission(quiz, submission)
-    } catch (err) {
-      throw new BadRequestException('Response does not match quiz definition')
+    } catch (err: any) {
+      throw new BadRequestException(
+        `Response does not match quiz definition: ${err.message}`
+      )
     }
 
     try {

--- a/backend/src/taker/taker.module.ts
+++ b/backend/src/taker/taker.module.ts
@@ -6,6 +6,7 @@ import { Quiz } from 'database/models'
 import { UserModule } from 'user/user.module'
 import { QuestionModule } from 'question/question.module'
 import { OptionModule } from 'option/option.module'
+import { TakerService } from './taker.service'
 
 @Module({
   imports: [
@@ -16,5 +17,6 @@ import { OptionModule } from 'option/option.module'
     OptionModule,
   ],
   controllers: [TakerController],
+  providers: [TakerService],
 })
 export class TakerModule {}

--- a/backend/src/taker/taker.service.ts
+++ b/backend/src/taker/taker.service.ts
@@ -1,0 +1,115 @@
+import { Quiz, Question } from '../database/models'
+import { SubmissionDto } from './dto/submit-quiz.dto'
+import _ from 'lodash'
+
+function asId(a: number, b: number) {
+  return a - b
+}
+
+export class TakerService {
+  assertValidSubmission(quiz: Quiz, submission: SubmissionDto): void {
+    // 0. verify that submission has a name
+    if (!submission.name?.length) {
+      throw new Error(`Submission came without a name`)
+    }
+
+    // 1. verify that all submitted questions and answers exist in quiz definition
+    submission.questions.forEach((submittedQuestion) => {
+      const quizQuestion = quiz.questions.find(
+        (question) => question.id === submittedQuestion.id
+      )
+
+      if (!quizQuestion) {
+        throw new Error(
+          `Submitted question ${submittedQuestion.id} not found in quiz definition.`
+        )
+      }
+
+      if (!submittedQuestion.answer.length) {
+        throw new Error(
+          `No answer submitted for question ${submittedQuestion.id}`
+        )
+      }
+
+      submittedQuestion.answer.forEach((optionId) => {
+        const quizOption = quizQuestion.options.find(
+          (option) => option.id === optionId
+        )
+
+        if (!quizOption) {
+          throw new Error(
+            `Submitted option ${optionId} not found in quiz definition.`
+          )
+        }
+      })
+    })
+
+    // 2. verify that all questions from the quiz have been answered
+    // TODO: when quiz subset are implemented, verify against quiz attempt definition in session instead
+    const missingQuestions = quiz.questions.filter((quizQuestion) => {
+      return !submission.questions.find(
+        (submittedQuestion) => submittedQuestion.id === quizQuestion.id
+      )
+    })
+    if (missingQuestions.length) {
+      throw new Error(
+        `Submission does not include answers to all questions. Missing ${missingQuestions.map(
+          (q) => q.id
+        )}`
+      )
+    }
+  }
+
+  mark(quiz: Quiz, submission: SubmissionDto): any {
+    const markResult = {
+      id: quiz.id,
+      result: {
+        score: 0,
+        total: 0,
+        pass: false,
+        passingPercent: quiz.passingPercent,
+      },
+      answers: [] as any[],
+    }
+
+    const { total, score } = submission.questions.reduce(
+      (acc, question) => {
+        const quizQuestion = quiz.questions.find(
+          (q) => q.id === question.id
+        ) as Question
+
+        acc.total += quizQuestion.pointValue
+
+        const correctAnswer = quizQuestion.options
+          .filter((o) => o.isTrue)
+          .map((o) => o.id)
+          .sort(asId)
+
+        question.answer.sort(asId)
+
+        const isCorrect = _.isEqual(question.answer, correctAnswer)
+
+        markResult.answers.push({
+          id: quizQuestion.id,
+          submittedAnswer: question.answer,
+          correctAnswer,
+          isCorrect,
+          explanation: quizQuestion.explanation,
+        })
+
+        if (isCorrect) {
+          acc.score += quizQuestion.pointValue
+        }
+
+        return acc
+      },
+      { total: 0, score: 0 }
+    )
+
+    markResult.result.score = score
+    markResult.result.total = total
+    markResult.result.pass = score / total >= quiz.passingPercent
+
+    return markResult
+  }
+}

--- a/backend/src/taker/taker.service.ts
+++ b/backend/src/taker/taker.service.ts
@@ -38,7 +38,7 @@ export class TakerService {
 
         if (!quizOption) {
           throw new Error(
-            `Submitted option ${optionId} not found in quiz definition.`
+            `Submitted option ${optionId} in question ${submittedQuestion.id} not found in quiz definition.`
           )
         }
       })


### PR DESCRIPTION
## Context

After the `/attempt` API for takers, the `/submission` API is needed.

## Approach
Implement handler for submissions, with format validation and marking.
