### PR TITLE
feat: firm up generate weblink alert modal

### DIFF
--- a/frontend/src/pages/CreatorLandingPage/CreatorQuizSummaryPage/CreatorQuizSummaryPage.tsx
+++ b/frontend/src/pages/CreatorLandingPage/CreatorQuizSummaryPage/CreatorQuizSummaryPage.tsx
@@ -18,7 +18,7 @@ import moment from 'moment-timezone'
 import { useFetchQuizWithSubmissions } from '~hooks/Creator'
 import Header from '~components/Header'
 
-import { convertDecimalToPercent } from './utils'
+import { convertDecimalToPercent, generateWeblinkDisplay } from './utils'
 
 const OVERVIEW_TABLE_CONFIG = [
   {
@@ -92,7 +92,7 @@ const CreatorQuizSummaryPage = (): JSX.Element => {
   const onClickBackToDashboard = () => history.replace('/creator')
 
   // TODO: to implement logic
-  const onClickGetQuizLink = () => alert(`${window.location.origin}/${quizId}`)
+  const onClickGetQuizLink = () => generateWeblinkDisplay(quizId)
   // TODO: to implement logic
   const onClickEditQuizLink = () => console.log('edit quiz link button pressed')
   // TODO: to implement logic

--- a/frontend/src/pages/CreatorLandingPage/CreatorQuizSummaryPage/utils.ts
+++ b/frontend/src/pages/CreatorLandingPage/CreatorQuizSummaryPage/utils.ts
@@ -1,2 +1,13 @@
 export const convertDecimalToPercent = (decimal: string): string =>
   `${Math.round(parseFloat(decimal) * 100)}%`
+
+export const generateWeblinkDisplay = (quizId: string): void => {
+  const url = `${window.location.origin}/${quizId}`
+  if (
+    window.confirm(
+      `Here is the link to the quiz for taker: ${url}. Click "OK" to open the quiz in a new tab, or "CANCEL" to not do so.`,
+    )
+  ) {
+    window.open(url)
+  }
+}


### PR DESCRIPTION
## Context

Alert modal will be displayed after creator of quiz clicks on 'Get Quiz Link' button on the Quiz result summary page.

Screenshot of modal:
<img width="440" alt="image" src="https://user-images.githubusercontent.com/43469989/155279970-c172b658-3515-4c62-863e-0b24fbfdb77f.png">
