### PR TITLE
feat: incoporate ulid into quiz

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -30,7 +30,8 @@
         "rxjs": "^7.4.0",
         "sequelize": "^6.8.0",
         "sequelize-typescript": "^2.1.3",
-        "sqlite3": "^5.0.2"
+        "sqlite3": "^5.0.2",
+        "ulid": "^2.3.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^8.1.4",
@@ -12081,6 +12082,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/ulid": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
+      "integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==",
+      "bin": {
+        "ulid": "bin/cli.js"
+      }
+    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -22061,6 +22070,11 @@
       "requires": {
         "random-bytes": "~1.0.0"
       }
+    },
+    "ulid": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
+      "integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,7 +46,8 @@
     "rxjs": "^7.4.0",
     "sequelize": "^6.8.0",
     "sequelize-typescript": "^2.1.3",
-    "sqlite3": "^5.0.2"
+    "sqlite3": "^5.0.2",
+    "ulid": "^2.3.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^8.1.4",

--- a/backend/src/creator/creator.controller.ts
+++ b/backend/src/creator/creator.controller.ts
@@ -20,7 +20,7 @@ import {
   CreateQuizResponseDto,
 } from './dto/create-quiz.dto'
 import { CreateOptionDB } from 'option/dto/create-option.dto'
-import { IsNumberStringValidator } from 'helpers/isNumberStringValidator'
+import { IsQuizIdPresentValidator } from 'helpers'
 import { GetQuizWithSubmissionsResponseDto } from './dto/get-quiz-with-submissions.dto'
 
 @Controller('creator')
@@ -101,12 +101,12 @@ export class CreatorController {
   @Get('quiz/:id')
   async get(
     @Res() res: Response,
-    @Param() param: IsNumberStringValidator
+    @Param() { id: quizId }: IsQuizIdPresentValidator
   ): Promise<void> {
     // TODO: to refactor when there are more than 1 admin user
     const admin = await this.userService.getFirst()
     if (!admin) throw new InternalServerErrorException('Admin user not present')
-    const quiz = await this.quizService.getQuiz(param.id)
+    const quiz = await this.quizService.getQuiz(quizId)
     if (!quiz) throw new NotFoundException()
 
     const numAttempts = quiz.submissions.length
@@ -128,12 +128,12 @@ export class CreatorController {
   @Delete('quiz/:id')
   async deleteOne(
     @Res() res: Response,
-    @Param() param: IsNumberStringValidator
+    @Param() { id: quizId }: IsQuizIdPresentValidator
   ): Promise<void> {
     // TODO: to refactor when there are more than 1 admin user
     const admin = await this.userService.getFirst()
     if (!admin) throw new InternalServerErrorException('Admin user not present')
-    const numDeleted = await this.quizService.deleteOnQuizId(param.id, admin.id)
+    const numDeleted = await this.quizService.deleteOnQuizId(quizId, admin.id)
     // TODO: to separate out 403 and 404 errors
     if (numDeleted === 0) throw new NotFoundException()
     res.status(HttpStatus.NO_CONTENT).send()

--- a/backend/src/database/models/quiz.ts
+++ b/backend/src/database/models/quiz.ts
@@ -52,7 +52,7 @@ export class Quiz extends Model {
   organisation!: string
 
   @Column({
-    type: DataType.STRING,
+    type: DataType.STRING(26),
     unique: true,
     allowNull: false,
   })

--- a/backend/src/database/models/quiz.ts
+++ b/backend/src/database/models/quiz.ts
@@ -53,6 +53,7 @@ export class Quiz extends Model {
 
   @Column({
     type: DataType.STRING,
+    unique: true,
     allowNull: false,
   })
   randomId!: string

--- a/backend/src/database/models/quiz.ts
+++ b/backend/src/database/models/quiz.ts
@@ -51,6 +51,12 @@ export class Quiz extends Model {
   })
   organisation!: string
 
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
+  randomId!: string
+
   @BelongsTo(() => User)
   user!: User
 

--- a/backend/src/helpers/index.ts
+++ b/backend/src/helpers/index.ts
@@ -1,0 +1,2 @@
+export { IsNumberStringValidator } from './isNumberStringValidator'
+export { IsQuizIdPresentValidator } from './isQuizIdPresentValidator'

--- a/backend/src/helpers/isQuizIdPresentValidator.ts
+++ b/backend/src/helpers/isQuizIdPresentValidator.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator'
+
+export class IsQuizIdPresentValidator {
+  @IsString()
+  id!: string
+}

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -7,6 +7,7 @@ import { CreateQuizResponseDto } from 'creator/dto/create-quiz.dto'
 import { AttemptResponseDto } from 'taker/dto/attempt-quiz.dto'
 import { CreateQuestionResponseDto } from 'question/dto/create-question.dto'
 import { QuizWithSubmissions } from './quiz.types'
+import { ulid } from 'ulid'
 
 @Injectable()
 export class QuizService {
@@ -31,6 +32,7 @@ export class QuizService {
         passingPercent,
         description,
         organisation,
+        randomId: ulid(),
       }),
       'dataValues'
     )
@@ -40,7 +42,7 @@ export class QuizService {
     return this.quizModel.findAll({ where: { ownerId: userId } })
   }
 
-  async deleteOnQuizId(quizId: number, userId: number): Promise<number> {
+  async deleteOnQuizId(quizId: string, userId: number): Promise<number> {
     return this.quizModel.destroy({
       where: { id: quizId, ownerId: userId },
     })
@@ -65,7 +67,7 @@ export class QuizService {
     } as CreateQuizResponseDto
   }
 
-  async getQuiz(quizId: number): Promise<QuizWithSubmissions | null> {
+  async getQuiz(quizId: string): Promise<QuizWithSubmissions | null> {
     return this.quizModel.findOne({
       include: [
         {
@@ -73,11 +75,11 @@ export class QuizService {
           attributes: ['name', 'scorePercent', 'submittedAt'],
         },
       ],
-      where: { id: quizId },
+      where: { randomId: quizId },
     })
   }
 
-  async getQuizWithQuestionsAndOptions(quizId: number): Promise<Quiz | null> {
+  async getQuizWithQuestionsAndOptions(quizId: string): Promise<Quiz | null> {
     return this.quizModel.findOne({
       include: [
         {
@@ -89,7 +91,7 @@ export class QuizService {
           ],
         },
       ],
-      where: { id: quizId },
+      where: { randomId: quizId },
     })
   }
 

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -44,7 +44,7 @@ export class QuizService {
 
   async deleteOnQuizId(quizId: string, userId: number): Promise<number> {
     return this.quizModel.destroy({
-      where: { id: quizId, ownerId: userId },
+      where: { randomId: quizId, ownerId: userId },
     })
   }
 

--- a/backend/src/taker/taker.controller.ts
+++ b/backend/src/taker/taker.controller.ts
@@ -14,7 +14,7 @@ import {
 } from '@nestjs/common'
 import { Response, Request } from 'express'
 import { QuizService } from 'quiz/quiz.service'
-import { IsNumberStringValidator } from 'helpers/isNumberStringValidator'
+import { IsQuizIdPresentValidator } from 'helpers'
 import { SubmissionRequestDto } from './dto/submit-quiz.dto'
 import { TakerService } from './taker.service'
 
@@ -28,9 +28,9 @@ export class TakerController {
   @Get('quiz/:id/attempt')
   async getAll(
     @Res() res: Response,
-    @Param() param: IsNumberStringValidator
+    @Param() { id: quizId }: IsQuizIdPresentValidator
   ): Promise<void> {
-    const quiz = await this.quizService.getQuizWithQuestionsAndOptions(param.id)
+    const quiz = await this.quizService.getQuizWithQuestionsAndOptions(quizId)
 
     // TODO: subset, randomization on questions and options
     // TODO: store quiz to user session (to prevent foul play on submission!)
@@ -46,9 +46,9 @@ export class TakerController {
     @Req() req: Request,
     @Res() res: Response,
     @Body() submission: SubmissionRequestDto,
-    @Param() param: IsNumberStringValidator
+    @Param() { id: quizId }: IsQuizIdPresentValidator
   ): Promise<void> {
-    const quiz = await this.quizService.getQuizWithQuestionsAndOptions(param.id)
+    const quiz = await this.quizService.getQuizWithQuestionsAndOptions(quizId)
 
     if (!quiz) throw new NotFoundException()
     try {

--- a/frontend/src/pages/CreatorLandingPage/CreatorLandingPage.tsx
+++ b/frontend/src/pages/CreatorLandingPage/CreatorLandingPage.tsx
@@ -24,8 +24,13 @@ const CREATE_QUIZ_BUTTON_TEXT = 'Create new quiz'
 
 const TABLE_CONFIG = [
   {
+    display: 'S/N',
+    key: '',
+    fn: (_unused: string) => '',
+  },
+  {
     display: 'Quiz ID',
-    key: 'id',
+    key: 'randomId',
     fn: (id: string) => id || '',
   },
   {
@@ -50,7 +55,7 @@ const CreatorLandingPage = (): JSX.Element => {
   const onClickCreateQuiz = () => history.push(`${path}/create`)
 
   // Click handler for each row to navigate to quiz result summary page
-  const onClickQuiz = (quizId: number) => history.push(`/creator/${quizId}`)
+  const onClickQuiz = (randomId: string) => history.push(`/creator/${randomId}`)
 
   return (
     <VStack bg="primary.100" minH="100vh">
@@ -83,21 +88,25 @@ const CreatorLandingPage = (): JSX.Element => {
           {/* Show quiz in table when call succeeds */}
           {fetchAllQuizzesStatus === 'success' ? (
             <Tbody>
-              {_.map(allQuizzes, (quiz) => {
-                const { id } = quiz
+              {_.map(allQuizzes, (quiz, sn) => {
+                const { randomId } = quiz
                 return (
                   <Tr
-                    key={id}
-                    onClick={() => onClickQuiz(id)}
+                    key={randomId}
+                    onClick={() => onClickQuiz(randomId)}
                     _hover={{
                       background: 'white',
                       color: 'primary.500',
                       cursor: 'pointer',
                     }}
                   >
-                    {_.map(TABLE_CONFIG, (config) => {
+                    {_.map(TABLE_CONFIG, (config, idx) => {
                       const { key, fn } = config
-                      return <Td key={key}>{fn(_.get(quiz, key))}</Td>
+                      return (
+                        <Td key={key}>
+                          {idx === 0 ? sn + 1 : fn(_.get(quiz, key))}
+                        </Td>
+                      )
                     })}
                   </Tr>
                 )

--- a/frontend/src/pages/CreatorLandingPage/CreatorQuizSummaryPage/CreatorQuizSummaryPage.tsx
+++ b/frontend/src/pages/CreatorLandingPage/CreatorQuizSummaryPage/CreatorQuizSummaryPage.tsx
@@ -170,7 +170,7 @@ const CreatorQuizSummaryPage = (): JSX.Element => {
           {fetchQuizWithSubmissionsStatus === 'success' &&
           quizWithSubmissions ? (
             <Tbody>
-              <Tr key={quizWithSubmissions.id}>
+              <Tr key={quizWithSubmissions.randomId}>
                 {_.map(OVERVIEW_TABLE_CONFIG, (config) => {
                   const { key, fn } = config
                   return (

--- a/frontend/src/services/QuizApi/creator/types.ts
+++ b/frontend/src/services/QuizApi/creator/types.ts
@@ -8,6 +8,7 @@ export type QuizCreationDto = {
 
 export type Quiz = QuizCreationDto & {
   id: number
+  randomId: string
   ownerId: number
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
## Context

We shouldn’t use the quizzes ID as they are (primary key in DB). The numbers are good for the DB auto-increment, but it means quizzes are too easily “browsable” (just increment/decrement the quiz ID from a given quiz URL to see other quizzes).

## Solution

Instead, we should have a level of random indirection with non-sequential alphanumerical IDs, and the library we would be using is [ULIDs](https://github.com/ulid/spec) for that. ULID is preferred over UUID, as reason shown in the docs. Primarily, we use ULID as it is shorter than UUID, hence the id string in the URL parameter is shorter and less cumbersome. 

Future consideration is to make this ULID even shorter and more compact, while maintaining uniqueness. Link to [Slack response](https://opengovproducts.slack.com/archives/C02TD0RFSUV/p1645605394545259).

