### PR TITLE
chore: refactor backend types

### DIFF
--- a/backend/src/creator/creator.controller.ts
+++ b/backend/src/creator/creator.controller.ts
@@ -45,10 +45,12 @@ export class CreatorController {
     const quiz = await this.quizService.createQuiz(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       admin!.id,
-      createQuizDto.name,
-      createQuizDto.passingPercent,
-      createQuizDto.description,
-      createQuizDto.organisation
+      {
+        name: createQuizDto.name,
+        passingPercent: createQuizDto.passingPercent,
+        description: createQuizDto.description,
+        organisation: createQuizDto.organisation,
+      }
     )
 
     // 2. Add row(s) to Question table

--- a/backend/src/creator/dto/create-quiz.dto.ts
+++ b/backend/src/creator/dto/create-quiz.dto.ts
@@ -1,4 +1,12 @@
-import { MinLength, IsNumber, Min, Max, IsNotEmpty } from 'class-validator'
+import { Type } from 'class-transformer'
+import {
+  MinLength,
+  IsNumber,
+  Min,
+  Max,
+  ArrayNotEmpty,
+  ValidateNested,
+} from 'class-validator'
 import { Quiz } from 'database/models'
 import {
   CreateQuestionRequestDto,
@@ -20,7 +28,9 @@ export class CreateQuizRequestDto {
   @MinLength(1)
   organisation!: string
 
-  @IsNotEmpty()
+  @ArrayNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => CreateQuestionRequestDto)
   questions!: CreateQuestionRequestDto[]
 }
 

--- a/backend/src/option/dto/create-option.dto.ts
+++ b/backend/src/option/dto/create-option.dto.ts
@@ -1,5 +1,6 @@
 import { MinLength, IsBoolean } from 'class-validator'
 import { Option } from 'database/models'
+import { OptionEditableFields } from 'option/options.types'
 
 export class CreateOptionRequestDto {
   @MinLength(1)
@@ -9,7 +10,7 @@ export class CreateOptionRequestDto {
   isTrue!: boolean
 }
 
-export type CreateOptionDB = CreateOptionRequestDto & {
+export type CreateOptionDB = OptionEditableFields & {
   questionId: number
 }
 

--- a/backend/src/option/option.service.ts
+++ b/backend/src/option/option.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 import { Option } from '../database/models'
 import { CreateOptionDB } from './dto/create-option.dto'
-import _ from 'lodash'
+import { get } from 'lodash'
 
 @Injectable()
 export class OptionService {
@@ -13,7 +13,9 @@ export class OptionService {
 
   async bulkCreate(optionsData: CreateOptionDB[]): Promise<Option[]> {
     // TODO: find a way to not use lodash wrapper
-    const rawData = await this.optionModel.bulkCreate(optionsData)
-    return rawData.map((data) => _.get(data, 'dataValues'))
+    const rawData = await this.optionModel.bulkCreate(optionsData, {
+      validate: true,
+    })
+    return rawData.map((data) => get(data, 'dataValues'))
   }
 }

--- a/backend/src/option/options.types.ts
+++ b/backend/src/option/options.types.ts
@@ -1,0 +1,3 @@
+import { Option } from 'database/models'
+
+export type OptionEditableFields = Pick<Option, 'text' | 'isTrue'>

--- a/backend/src/question/dto/create-question.dto.ts
+++ b/backend/src/question/dto/create-question.dto.ts
@@ -1,13 +1,16 @@
+import { Type } from 'class-transformer'
 import {
   MinLength,
   IsIn,
   IsInt,
   Min,
-  IsNotEmpty,
   ValidateIf,
+  ArrayNotEmpty,
+  ValidateNested,
 } from 'class-validator'
 import { Option, Question, QuestionType, QUESTION_TYPES } from 'database/models'
 import { CreateOptionRequestDto } from 'option/dto/create-option.dto'
+import { QuestionEditableFields } from 'question/question.types'
 
 export class CreateQuestionRequestDto {
   @MinLength(1)
@@ -30,11 +33,13 @@ export class CreateQuestionRequestDto {
   @Min(0)
   pointValue!: number
 
-  @IsNotEmpty()
+  @ArrayNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => CreateOptionRequestDto)
   options!: CreateOptionRequestDto[]
 }
 
-export type CreateQuestionDB = Omit<CreateQuestionRequestDto, 'options'> & {
+export type CreateQuestionDB = QuestionEditableFields & {
   quizId: number
 }
 

--- a/backend/src/question/question.service.ts
+++ b/backend/src/question/question.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 import { CreateQuestionDB } from 'question/dto/create-question.dto'
 import { Question } from '../database/models'
-import _ from 'lodash'
+import { get } from 'lodash'
 
 @Injectable()
 export class QuestionService {
@@ -13,7 +13,9 @@ export class QuestionService {
 
   async bulkCreate(questionsData: CreateQuestionDB[]): Promise<Question[]> {
     // TODO: find a way to not use lodash wrapper
-    const rawData = await this.questionModel.bulkCreate(questionsData)
-    return rawData.map((data) => _.get(data, 'dataValues'))
+    const rawData = await this.questionModel.bulkCreate(questionsData, {
+      validate: true,
+    })
+    return rawData.map((data) => get(data, 'dataValues'))
   }
 }

--- a/backend/src/question/question.types.ts
+++ b/backend/src/question/question.types.ts
@@ -1,0 +1,6 @@
+import { Question } from 'database/models'
+
+export type QuestionEditableFields = Pick<
+  Question,
+  'text' | 'details' | 'explanation' | 'mediaURL' | 'pointValue'
+>

--- a/backend/src/quiz/quiz.service.ts
+++ b/backend/src/quiz/quiz.service.ts
@@ -2,11 +2,11 @@
 import { Injectable } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 import { Option, Question, Quiz, Submission } from '../database/models'
-import _ from 'lodash'
+import { get } from 'lodash'
 import { CreateQuizResponseDto } from 'creator/dto/create-quiz.dto'
 import { AttemptResponseDto } from 'taker/dto/attempt-quiz.dto'
 import { CreateQuestionResponseDto } from 'question/dto/create-question.dto'
-import { QuizWithSubmissions } from './quiz.types'
+import { QuizEditableFields, QuizWithSubmissions } from './quiz.types'
 import { ulid } from 'ulid'
 
 @Injectable()
@@ -17,21 +17,12 @@ export class QuizService {
   ) {}
 
   // TODO: incomplete. missing quiz questions
-  async createQuiz(
-    userId: number,
-    name: string,
-    passingPercent: number,
-    description: string,
-    organisation: string
-  ): Promise<Quiz> {
+  async createQuiz(userId: number, fields: QuizEditableFields): Promise<Quiz> {
     // TODO: find a way to not use lodash wrapper
-    return _.get(
+    return get(
       await this.quizModel.create({
-        name,
         ownerId: userId,
-        passingPercent,
-        description,
-        organisation,
+        ...fields,
         randomId: ulid(),
       }),
       'dataValues'

--- a/backend/src/quiz/quiz.types.ts
+++ b/backend/src/quiz/quiz.types.ts
@@ -3,3 +3,8 @@ import { Quiz, Submission } from 'database/models'
 export type QuizWithSubmissions = Omit<Quiz, 'submissions'> & {
   submissions: Pick<Submission, 'name' | 'scorePercent' | 'submittedAt'>[]
 }
+
+export type QuizEditableFields = Pick<
+  Quiz,
+  'name' | 'passingPercent' | 'description' | 'organisation'
+>


### PR DESCRIPTION
## Changes

- Abstract out editable fields of `Quiz`, `Question` and `Option` model to reduce repeated syntax.
- Import only the function utilised from `lodash`.
- Allow `class-validator` to perform validation of nested attributes, i.e. `class-validator` checks of `Question` and `Option` types in `Quiz` operations are also performed, and therefore returning a 400 error if `Question` and `Option` object(s) are malformed in request body.